### PR TITLE
Add PR preview workflows for website

### DIFF
--- a/.github/workflows/pr-preview-worker.yml
+++ b/.github/workflows/pr-preview-worker.yml
@@ -1,0 +1,20 @@
+name: PR Preview (worker)
+
+on:
+  workflow_run:
+    workflows: ["PR Preview"]
+    types: [completed]
+
+jobs:
+  pr-preview-fork-deploy:
+    permissions:
+      contents: read
+      actions: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: PR preview (worker)
+        uses: open-resource-discovery/pr-preview-action@main
+        with:
+          token: ${{ secrets.PR_PREVIEW_TOKEN }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -46,7 +46,7 @@ jobs:
       - name: PR preview
         uses: open-resource-discovery/pr-preview-action@main
         with:
-          fork: true
+        #  fork: true
           build-dir: website/build
           target-repo: SAP/csn-interop-pr-preview
           pages-base-url: https://sap.github.io/csn-interop-pr-preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,54 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+jobs:
+  pr-preview:
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: preview-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install website dependencies
+        if: github.event.action != 'closed'
+        working-directory: ./website
+        run: npm ci
+
+      - name: Build preview
+        if: github.event.action != 'closed'
+        working-directory: ./website
+        env:
+          PR_PREVIEW_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_URL: /csn-interop-renderer/pr-${{ github.event.pull_request.number }}/
+        run: |
+          set -euo pipefail
+          npm run build
+
+      - name: PR preview
+        uses: open-resource-discovery/pr-preview-action@main
+        with:
+          fork: true
+          build-dir: website/build
+          target-repo: SAP/csn-interop-pr-preview
+          pages-base-url: https://sap.github.io/csn-interop-pr-preview
+          umbrella-dir: csn-interop-renderer
+          token: ${{ secrets.PR_PREVIEW_TOKEN }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./website
         env:
           PR_PREVIEW_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_URL: /csn-interop-renderer/pr-${{ github.event.pull_request.number }}/
+          BASE_URL: /csn-interop-pr-preview/csn-interop-renderer/pr-${{ github.event.pull_request.number }}/
         run: |
           set -euo pipefail
           npm run build

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -46,7 +46,7 @@ jobs:
       - name: PR preview
         uses: open-resource-discovery/pr-preview-action@main
         with:
-        #  fork: true
+          fork: true
           build-dir: website/build
           target-repo: SAP/csn-interop-pr-preview
           pages-base-url: https://sap.github.io/csn-interop-pr-preview

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,11 +4,14 @@ import type * as Preset from "@docusaurus/preset-classic";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+const isPrPreview = Boolean(process.env.PR_PREVIEW_NUMBER);
+const baseUrl = process.env.BASE_URL || "/csn-interop-renderer/";
+
 const config: Config = {
   title: "CSN Interop Document Renderer",
   tagline: "A tool to generate markdown documentation from CSN JSON documents",
   url: "https://sap.github.io",
-  baseUrl: "/csn-interop-renderer/",
+  baseUrl,
   trailingSlash: false,
   onBrokenLinks: "throw",
   onBrokenAnchors: "warn",
@@ -68,6 +71,16 @@ const config: Config = {
         },
       ],
     },
+    ...(isPrPreview
+      ? {
+          announcementBar: {
+            content: `<b>This is a preview version of the website for <a href="https://github.com/SAP/csn-interop-renderer/pull/${process.env.PR_PREVIEW_NUMBER}" target="_blank" rel="noopener noreferrer">PR #${process.env.PR_PREVIEW_NUMBER}</a></b>`,
+            backgroundColor: "#e65050ff",
+            textColor: "#fff",
+            isCloseable: false,
+          },
+        }
+      : {}),
     footer: {
       style: "dark",
       copyright: `Copyright © ${new Date().getFullYear()} SAP SE. Made available under Apache License 2.0.\n\n This site is hosted by GitHub Pages. Please see the GitHub Privacy Statement for any information how GitHub processes your personal data.`,


### PR DESCRIPTION
## Summary

Add PR preview support for the website.

## Changes

- add PR preview workflows
- make `BASE_URL` configurable for preview builds
- show a small PR preview banner

## Note

Our `pr-preview-action` builds and publishes a temporary preview site for each PR and removes it again when the PR is closed.